### PR TITLE
Resolves #125

### DIFF
--- a/bin/mlst
+++ b/bin/mlst
@@ -301,7 +301,6 @@ sub find_mlst {
   my @sig = ( [ ($scheme || '-'), '-', join("/", ('-') x $allele_cnt), 0 ] );  # sentinel
 
   for my $name (keys %res) {
-    msg("name: $name\n");
     my $sig = $scheme{$name}->signature_of($res{$name});
     my $ST = $scheme{$name}->sequence_type($sig);
 

--- a/bin/mlst
+++ b/bin/mlst
@@ -100,6 +100,13 @@ msg("Excluding $num_excluded schemes:", (keys %exclude)) if $num_excluded > 0;
 
 my $json;
 
+my $allele_cnt = 7;
+
+# If --scheme is set, set the length for initialising @sig to the number of alleles in $scheme
+if ($scheme) {
+  $allele_cnt = @{$scheme{$scheme}->genes};
+}
+
 # output the header for the old style syntax 
 if ($scheme and $legacy) {
   print join($OUTSEP, qw(FILE SCHEME ST), @{ $scheme{$scheme}->genes } ),"\n";
@@ -290,10 +297,11 @@ sub find_mlst {
     }
   }
 
-  # find the signature with the fewest missing/approximate alleles  
-  my @sig = ( [ ($scheme || '-'), '-', join("/", ('-')x7), 0 ] );  # sentinel
+  # find the signature with the fewest missing/approximate alleles
+  my @sig = ( [ ($scheme || '-'), '-', join("/", ('-') x $allele_cnt), 0 ] );  # sentinel
 
   for my $name (keys %res) {
+    msg("name: $name\n");
     my $sig = $scheme{$name}->signature_of($res{$name});
     my $ST = $scheme{$name}->sequence_type($sig);
 


### PR DESCRIPTION
The size of the signature array (`@sig`) was hardcoded as 7.
I have changed it to be equal to the length of the number of genes in `$scheme` when `--scheme` is set by the user.

Resolves Issue #125, and now gives correct output for examples provided.