### PR TITLE
Add retry option to curl command of mlst-download_pub_mlst

### DIFF
--- a/scripts/mlst-download_pub_mlst
+++ b/scripts/mlst-download_pub_mlst
@@ -9,7 +9,8 @@ use Cwd 'abs_path';
 
 my $EXE = basename($0);
 my $URL = 'http://pubmlst.org/data/dbases.xml';
-my $CURL = "curl --silent";
+my $RETRIES = 5
+my $CURL = "curl --silent --retry $RETRIES";
 
 my %opt = (
   'd' => '',


### PR DESCRIPTION
Flaky connections leads to failed download, and one must re-download the entire PubMed DB, rather than restarting, adding --retry to the curl command, increased chance of success.

Suggested 5 retries in total.
From the curl Man
"""
--retry <num>
              If a transient error is returned when curl tries to perform a transfer, it retries this number of times before giving up.  Setting
              the number to 0 makes curl do no retries (which is the default). ...
"""

IF maximum download time is a concern --retry-max-time could be relevant.