### PR TITLE
Add status and score to JSON output

### DIFF
--- a/bin/mlst
+++ b/bin/mlst
@@ -17,7 +17,7 @@ use MLST::Requirements qw(require_exe);
 #..............................................................................
 # Globals
 
-my $VERSION = '2.32.3';
+my $VERSION = '2.32.4';
 my $EXE = path($FindBin::RealScript)->basename;
 my $AUTHOR = 'Torsten Seemann';
 my $URL = 'https://github.com/tseemann/mlst';
@@ -208,8 +208,10 @@ for my $argv (@ARGV) {
       'filename' => $argv,
       'scheme' => $sch,
       'sequence_type' => $ST,
-      'alleles' => $sch eq '-' 
-        ? undef 
+      'status' => status_column($ST, $score, @code),
+      'score' => $score,
+      'alleles' => $sch eq '-'
+        ? undef
         : { (pairwise { ($a=>$b) } @{$scheme{$sch}->genes}, @code) },
     };
   }

--- a/test/test.sh
+++ b/test/test.sh
@@ -139,7 +139,9 @@ setup() {
   local outfile="${BATS_TMPDIR}/$name.json"
   run -0 $exe --json "$outfile" example.fna.gz
   [[ -r "$outfile" ]]
-  run -0 grep 'sequence_type' "$outfile"
+  run -0 grep '"sequence_type"' "$outfile"
+  run -0 grep '"status"' "$outfile"
+  run -0 grep '"score"' "$outfile"
 }
 @test "Using --outfile" {
   local outfile="${BATS_TMPDIR}/$name.tsv"


### PR DESCRIPTION
## Summary
- Adds `status` and `score` fields to the JSON output, matching the `--full` TSV/CSV output
- Bumps version to 2.32.4
- Updates JSON output test to verify new fields

Fixes #170