### PR TITLE
Allow decimal allele IDs in BLAST parsing and duplicate sorting

### DIFF
--- a/bin/mlst
+++ b/bin/mlst
@@ -171,7 +171,7 @@ for my $argv (@ARGV) {
   
   # sort duplicate alleles numerically (only for pure 100% ones)
   for my $as (@code) {
-    if ($as =~ m/,/ and $as =~ m/^[0-9,]+/) {
+    if ($as =~ m/,/ and $as =~ m/^[\d.,]+$/) {
       #print STDERR "DEBUG: '$as' in [@code]\n";
       $as = join ',', sort { $a <=> $b } split m/,/, $as;
       #print STDERR "DEBUG: '$as' in [@code]\n";
@@ -317,7 +317,7 @@ sub find_mlst {
 
   foreach (<$hits>) {
     chomp;
-    next unless m/ ^ (\w+)\.(\w+)[_-](\d+) 
+    next unless m/ ^ (\w+)\.(\w+)[_-](\d+(?:\.\d+)?) 
                    \t (\d+) \t (\d+) \t (\d+) 
                    \t (\S+) \t (\d+) \t (\d+) \t (\S+) \t (\S+) /x;
     my($sch, $gene, $num, $hlen, $alen, $nident, $qid, $qstart, $qend, $qseq, $sstrand) = ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11);

--- a/test/test.sh
+++ b/test/test.sh
@@ -112,12 +112,12 @@ setup() {
 }
 
 @test "Decimal allele IDs are reported" {
-  run -0 perl -e '$line = "ngstar.penA_2.002\t884\t884\t884\tq1\t1\t884\tACGT\tplus"; $line =~ m/^ (\\w+)\\.(\\w+)[_-](\\d+(?:\\.\\d+)?) \\t (\\d+) \\t (\\d+) \\t (\\d+) \\t (\\S+) \\t (\\d+) \\t (\\d+) \\t (\\S+) \\t (\\S+) $/x or exit 1; print "$1 $2 $3"'
-  [[ "$output" == "ngstar penA 2.002" ]]
+   run -0 perl -e '$line = "ngstar.penA_2.002\t884\t884\t884\tq1\t1\t884\tACGT\tplus"; $line =~ m/^ (\w+)\.(\w+)[_-](\d+(?:\.\d+)?) \t (\d+) \t (\d+) \t (\d+) \t (\S+) \t (\d+) \t (\d+) \t (\S+) \t (\S+) $/x or exit 1; print "$1 $2 $3"'
+   [[ "$output" == "ngstar penA 2.002" ]]
 }
 
 @test "Decimal duplicate alleles sort numerically" {
-  run -0 perl -e '$as = "10.001,2.002,2.001"; if ($as =~ m/,/ and $as =~ m/^[\\d.,]+$/) { $as = join ",", sort { $a <=> $b } split m/,/, $as; } print $as'
+  run -0 perl -e '$as = "10.001,2.002,2.001"; if ($as =~ m/,/ and $as =~ m/^[\d.,]+$/) { $as = join ",", sort { $a <=> $b } split m/,/, $as; } print $as'
   [[ "$output" == "2.001,2.002,10.001" ]]
 }
 @test "CSV output" {

--- a/test/test.sh
+++ b/test/test.sh
@@ -110,6 +110,16 @@ setup() {
   [[ "$output" =~ "atpA(1,1)" ]]
   [[ "$output" =~ "WARNING"  ]]
 }
+
+@test "Decimal allele IDs are reported" {
+  run -0 perl -e '$line = "ngstar.penA_2.002\t884\t884\t884\tq1\t1\t884\tACGT\tplus"; $line =~ m/^ (\\w+)\\.(\\w+)[_-](\\d+(?:\\.\\d+)?) \\t (\\d+) \\t (\\d+) \\t (\\d+) \\t (\\S+) \\t (\\d+) \\t (\\d+) \\t (\\S+) \\t (\\S+) $/x or exit 1; print "$1 $2 $3"'
+  [[ "$output" == "ngstar penA 2.002" ]]
+}
+
+@test "Decimal duplicate alleles sort numerically" {
+  run -0 perl -e '$as = "10.001,2.002,2.001"; if ($as =~ m/,/ and $as =~ m/^[\\d.,]+$/) { $as = join ",", sort { $a <=> $b } split m/,/, $as; } print $as'
+  [[ "$output" == "2.001,2.002,10.001" ]]
+}
 @test "CSV output" {
   run -0 $exe --csv mixed.fa.zip
   [[ "${lines[0]}" =~ ",\"MLST_gyrB(1,1)\"," ]]  


### PR DESCRIPTION
This PR updates the BLAST hit parsing regex in mlst to accept decimal allele IDs (e.g. penA_2.002) and also modifies the duplicate allele sorting logic to handle decimal IDs correctly. 
A focused regression test case is added to test.sh to confirm that decimal allele IDs are now parsed and sorted as expected. Addresses #180.

**Changes**: 
- Updated duplicate-allele sort guard to include decimal tokens in mlst.
- Updated BLAST hit allele capture to accept integer or decimal allele IDs in mlst.
- Added a regression test case in test.sh.

**Testing**:
- Ran the mlst with ngstar scheme against a test file containing decimal allele IDs in the BLAST database, confirming that decimal alleles are now reported correctly.

```
=== previous MLST without decimal allele fix ===
FILE	SCHEME	ST	penA	mtrR	porB	ponA	gyrA	parC	23S
test.fa	ngstar	-	-	42	-	100	10	2	100

=== new MLST with decimal allele fix ===
FILE	SCHEME	ST	penA	mtrR	porB	ponA	gyrA	parC	23S
test.fa	ngstar	-	2.002	42	-	100	10	2	100
```