### PR TITLE
Add MLST_DBDIR environment variable support for default database paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,9 +334,9 @@ attempting to run `mlst`.
 
 If you want `mlst` to use a different bundled database
 location by default, set `MLST_DBDIR` to the directory
-containing the `db` folder. This changes the default `--blastdb`
-path to `MLST_DBDIR/blast/mlst.fa` and the default `--datadir`
-path to `MLST_DBDIR/pubmlst`. Explicit `--blastdb`
+containing the `blast` and `pubmlst` folders. This changes
+the default `--blastdb` path to `MLST_DBDIR/blast/mlst.fa`
+and the default `--datadir` path to `MLST_DBDIR/pubmlst`. Explicit `--blastdb`
 and `--datadir` options still override these defaults.
 
 ## Adding a scheme 

--- a/README.md
+++ b/README.md
@@ -332,11 +332,12 @@ sure it's in `/path/to/mlst/db/pubmlst`
 and run `scripts/mlst-make_blast_db` before
 attempting to run `mlst`.
 
-If you want `mlst` to use a different bundled database location by default,
-set `MLSTDB_DIR` to your environment. This changes the default `--blastdb`
-path to `MLSTDB_DIR/blast/mlst.fa` and the default `--datadir` path to
-`MLSTDB_DIR/pubmlst`. Explicit `--blastdb` and `--datadir` options still
-override these defaults.
+If you want `mlst` to use a different bundled database
+location by default, set `MLST_DBDIR` to the directory
+containing the `db` folder. This changes the default `--blastdb`
+path to `MLST_DBDIR/blast/mlst.fa` and the default `--datadir`
+path to `MLST_DBDIR/pubmlst`. Explicit `--blastdb`
+and `--datadir` options still override these defaults.
 
 ## Adding a scheme 
 

--- a/README.md
+++ b/README.md
@@ -332,6 +332,12 @@ sure it's in `/path/to/mlst/db/pubmlst`
 and run `scripts/mlst-make_blast_db` before
 attempting to run `mlst`.
 
+If you want `mlst` to use a different bundled database location by default,
+set `MLSTDB_DIR` to your environment. This changes the default `--blastdb`
+path to `MLSTDB_DIR/blast/mlst.fa` and the default `--datadir` path to
+`MLSTDB_DIR/pubmlst`. Explicit `--blastdb` and `--datadir` options still
+override these defaults.
+
 ## Adding a scheme 
 
 If you want to add a custom private scheme

--- a/bin/mlst
+++ b/bin/mlst
@@ -463,8 +463,8 @@ sub setOptions {
     {OPT=>"mincov=f",   VAR=>\$mincov,   DEFAULT=>50, DESC=>"DNA %cov to report partial/'?' allele"},
     {OPT=>"minscore=f", VAR=>\$minscore, DEFAULT=>50, DESC=>"Minumum score out of 100 to match a scheme (when auto --scheme)"},
     "DATABASE",
-    {OPT=>"blastdb=s",  VAR=>\$blastdb,  DEFAULT=>path("$FindBin::RealBin/../db/blast/mlst.fa")->realpath, DESC=>"BLAST database prefix"},
-    {OPT=>"datadir=s",  VAR=>\$datadir,  DEFAULT=>path("$FindBin::RealBin/../db/pubmlst")->realpath, DESC=>"PubMLST data folders"},
+    {OPT=>"blastdb=s",  VAR=>\$blastdb,  DEFAULT=>path(($ENV{MLSTDB_DIR} || "$FindBin::RealBin/../db")."/blast/mlst.fa")->realpath, DESC=>"BLAST database prefix [default via MLSTDB_DIR/blast/mlst.fa; --blastdb overrides]"},
+    {OPT=>"datadir=s",  VAR=>\$datadir,  DEFAULT=>path(($ENV{MLSTDB_DIR} || "$FindBin::RealBin/../db")."/pubmlst")->realpath, DESC=>"PubMLST data folders [default via MLSTDB_DIR/pubmlst; --datadir overrides]"},
   );
   GetOptions(map {$_->{OPT}, $_->{VAR}} grep { ref }  @Options)
     or exit(1);

--- a/bin/mlst
+++ b/bin/mlst
@@ -17,7 +17,7 @@ use MLST::Requirements qw(require_exe);
 #..............................................................................
 # Globals
 
-my $VERSION = '2.34.0';
+my $VERSION = '2.34.1';
 my $EXE = path($FindBin::RealScript)->basename;
 my $AUTHOR = 'Torsten Seemann';
 my $URL = 'https://github.com/tseemann/mlst';

--- a/bin/mlst
+++ b/bin/mlst
@@ -17,7 +17,7 @@ use MLST::Requirements qw(require_exe);
 #..............................................................................
 # Globals
 
-my $VERSION = '2.34.1';
+my $VERSION = '2.35.0';
 my $EXE = path($FindBin::RealScript)->basename;
 my $AUTHOR = 'Torsten Seemann';
 my $URL = 'https://github.com/tseemann/mlst';

--- a/bin/mlst
+++ b/bin/mlst
@@ -25,6 +25,9 @@ my $URL = 'https://github.com/tseemann/mlst';
 # this is just the default schemes to exclude
 my $EXCLUDE = 'ecoli,abaumannii,vcholerae_2,senterica_achtman_2';
 
+# database directory from MLST_DBDIR or default to parent of script
+my $MLST_DBDIR = path($ENV{MLST_DBDIR} || "$FindBin::RealBin/..")->realpath;
+
 # internal symbols
 my $SEP = '/';
 my $SEEN = 'N';
@@ -71,6 +74,8 @@ if ($fofn) {
 }
 
 ($label && @ARGV > 1) and err("Using --label when scanning multiple files does not make sense");
+
+-d $MLST_DBDIR or err("Database directory does not exist: $MLST_DBDIR");
 
 
 $legacy && ! $scheme and err("Must specify a --scheme for --legacy output mode");
@@ -463,8 +468,8 @@ sub setOptions {
     {OPT=>"mincov=f",   VAR=>\$mincov,   DEFAULT=>50, DESC=>"DNA %cov to report partial/'?' allele"},
     {OPT=>"minscore=f", VAR=>\$minscore, DEFAULT=>50, DESC=>"Minumum score out of 100 to match a scheme (when auto --scheme)"},
     "DATABASE",
-    {OPT=>"blastdb=s",  VAR=>\$blastdb,  DEFAULT=>path(($ENV{MLSTDB_DIR} || "$FindBin::RealBin/../db")."/blast/mlst.fa")->realpath, DESC=>"BLAST database prefix [default via MLSTDB_DIR/blast/mlst.fa; --blastdb overrides]"},
-    {OPT=>"datadir=s",  VAR=>\$datadir,  DEFAULT=>path(($ENV{MLSTDB_DIR} || "$FindBin::RealBin/../db")."/pubmlst")->realpath, DESC=>"PubMLST data folders [default via MLSTDB_DIR/pubmlst; --datadir overrides]"},
+    {OPT=>"blastdb=s",  VAR=>\$blastdb,  DEFAULT=>path("$MLST_DBDIR/blast/mlst.fa")->realpath, DESC=>"BLAST database prefix [default via MLST_DBDIR/blast/mlst.fa; --blastdb overrides]"},
+    {OPT=>"datadir=s",  VAR=>\$datadir,  DEFAULT=>path("$MLST_DBDIR/pubmlst")->realpath, DESC=>"PubMLST data folders [default via MLST_DBDIR/pubmlst; --datadir overrides]"},
   );
   GetOptions(map {$_->{OPT}, $_->{VAR}} grep { ref }  @Options)
     or exit(1);

--- a/bin/mlst
+++ b/bin/mlst
@@ -25,8 +25,8 @@ my $URL = 'https://github.com/tseemann/mlst';
 # this is just the default schemes to exclude
 my $EXCLUDE = 'ecoli,abaumannii,vcholerae_2,senterica_achtman_2';
 
-# database directory from MLST_DBDIR or default to parent of script
-my $MLST_DBDIR = path($ENV{MLST_DBDIR} || "$FindBin::RealBin/..")->realpath;
+# database directory from MLST_DBDIR or default to bundled db folder
+my $MLST_DBDIR = path($ENV{MLST_DBDIR} || "$FindBin::RealBin/../db")->realpath;
 
 # internal symbols
 my $SEP = '/';

--- a/test/test.sh
+++ b/test/test.sh
@@ -38,6 +38,10 @@ setup() {
   run -0 $exe --list
   [[ "$output" =~ "saureus" ]]
 }
+@test "List schemes with MLSTDB_DIR" {
+  run -0 env MLSTDB_DIR="$dir/../db" $exe --list
+  [[ "$output" =~ "saureus" ]]
+}
 @test "List schemes --longlist" {
   run -0 $exe --longlist
   [[ "$output" =~ "saureus" ]]

--- a/test/test.sh
+++ b/test/test.sh
@@ -38,8 +38,8 @@ setup() {
   run -0 $exe --list
   [[ "$output" =~ "saureus" ]]
 }
-@test "List schemes with MLSTDB_DIR" {
-  run -0 env MLSTDB_DIR="$dir/../db" $exe --list
+@test "List schemes with MLST_DBDIR" {
+  run -0 env MLST_DBDIR="$dir/.." $exe --list
   [[ "$output" =~ "saureus" ]]
 }
 @test "List schemes --longlist" {

--- a/test/test.sh
+++ b/test/test.sh
@@ -39,7 +39,7 @@ setup() {
   [[ "$output" =~ "saureus" ]]
 }
 @test "List schemes with MLST_DBDIR" {
-  run -0 env MLST_DBDIR="$dir/.." $exe --list
+  run -0 env MLST_DBDIR="$dir/../db" $exe --list
   [[ "$output" =~ "saureus" ]]
 }
 @test "List schemes --longlist" {


### PR DESCRIPTION
This PR adds support for an `MLST_DBDIR` environment variable that sets the default paths for the BLAST database and PubMLST data directories in mlst. Addresses #30.
If `MLST_DBDIR` is set, the default `--blastdb` path will be `MLST_DBDIR/blast/mlst.fa` and the default `--datadir` path will be `MLST_DBDIR/pubmlst`. Explicit `--blastdb` and `--datadir` options will still override these defaults. The README is updated to document this new environment variable, and a test case is added to confirm that listing schemes works correctly when `MLST_DBDIR` is set.

**Changes**:
- Added support for the `MLST_DBDIR` environment variable to set default database paths in mlst.
- Updated README to include usage of `MLST_DBDIR` environment variable.
- Added a test case to confirm that listing schemes works with `MLST_DBDIR` set.